### PR TITLE
Add http protocol to the hash value when deidentifying urls with protocol missing

### DIFF
--- a/lib/deidentify/hash_url.rb
+++ b/lib/deidentify/hash_url.rb
@@ -4,6 +4,7 @@ module Deidentify
       return nil if old_url.nil?
 
       uri = URI.parse(old_url)
+      uri = URI.parse("http://#{old_url}") if uri.scheme.nil?
 
       hash_length = calculate_hash_length(uri, length)
 

--- a/test/deidentify/hash_url_test.rb
+++ b/test/deidentify/hash_url_test.rb
@@ -43,6 +43,15 @@ describe Deidentify::HashUrl do
     end
   end
 
+  describe "when there is no protocol" do
+    let(:old_url) { "www.wardrobe.com" }
+
+    it "adds the protocol http" do
+      Deidentify::Hash.expects(:call).with("www.wardrobe.com", length: 244).returns("host")
+      assert_equal new_url, "http://host"
+    end
+  end
+
   describe "when a length is provided" do
     let(:new_url) { Deidentify::HashUrl.call(old_url, length: length) }
     let(:old_url) { "https://wardrobe.com/path/to/narnia?id=2&name=edmund#white-witchs-castle" }


### PR DESCRIPTION
Before when hashing url without a protocol defined URI would detect the host as part of the path, so it would generate the a value starting with `/`.

In here, when the original url value doesn't have a protocol the `http` is used so that URI can parse it correctly.
