### PR TITLE
Allow classess to include Deidentify without defining any policy

### DIFF
--- a/lib/deidentify.rb
+++ b/lib/deidentify.rb
@@ -30,6 +30,10 @@ module Deidentify
     keep: Deidentify::Keep,
     delocalize_ip: Deidentify::DelocalizeIp,
   }
+  included do
+    class_attribute :deidentify_configuration
+    self.deidentify_configuration = {}
+  end
 
   module ClassMethods
     def deidentify(column, method:, **options)
@@ -37,20 +41,11 @@ module Deidentify
         raise Deidentify::Error.new("you must specify a valid deidentification method")
       end
 
-      if !respond_to?(:deidentify_configuration)
-        class_attribute :deidentify_configuration
-        self.deidentify_configuration = {}
-      end
-
       deidentify_configuration[column] = [method, options]
     end
   end
 
   def deidentify!
-    if !respond_to?(:deidentify_configuration)
-      raise Deidentify::Error.new("There is no deidentification configuration for this class")
-    end
-
     ActiveRecord::Base.transaction do
       self.deidentify_configuration.each_pair do |col, config|
         policy, options = Array(config)

--- a/test/deidentify_test.rb
+++ b/test/deidentify_test.rb
@@ -17,6 +17,14 @@ describe Deidentify do
   let(:old_colour) { "blue@eiffel65.com" }
   let(:old_quantity) { 150 }
 
+  describe "no policy is defined" do
+    it "ignores all columns" do
+      bubble.deidentify!
+      assert_equal bubble.colour, old_colour
+      assert_equal bubble.quantity, old_quantity
+    end
+  end
+
   describe "the policy is invalid" do
     it "raises an error" do
       assert_raises(Deidentify::Error) { Bubble.deidentify :colour, method: :pop }


### PR DESCRIPTION
Allow classess to include Deidentify without defining any policy: columns will simply be ignored and old values kept