### PR TITLE
Replace will now return nil if given a nil value

### DIFF
--- a/lib/deidentify/replace.rb
+++ b/lib/deidentify/replace.rb
@@ -1,6 +1,8 @@
 module Deidentify
   class Replace
-    def self.call(old_value, new_value:)
+    def self.call(old_value, new_value:, keep_nil: true)
+      return nil if old_value.nil? && keep_nil
+
       new_value
     end
   end

--- a/spec/deidentify/replace_spec.rb
+++ b/spec/deidentify/replace_spec.rb
@@ -1,10 +1,29 @@
 require 'spec_helper'
 
 describe Deidentify::Replace do
-  let(:new_value) { Deidentify::Replace.call("old", new_value: replacement) }
+  let(:new_value) { Deidentify::Replace.call(old_value, new_value: replacement) }
   let(:replacement) { "new" }
+  let(:old_value) { "old" }
 
   it "returns the new value" do
     expect(new_value).to eq(replacement)
+  end
+
+  context "when the old value is nil" do
+    let(:old_value) { nil }
+
+    context "nils should be retained" do
+      it "returns nil" do
+        expect(new_value).to be_nil
+      end
+    end
+
+    context "nils should be replaced" do
+      let(:new_value) { Deidentify::Replace.call(old_value, new_value: replacement, keep_nil: false) }
+
+      it "returns the new value" do
+        expect(new_value).to eq(replacement)
+      end
+    end
   end
 end

--- a/spec/deidentify_spec.rb
+++ b/spec/deidentify_spec.rb
@@ -76,6 +76,47 @@ describe Deidentify do
         expect(bubble.quantity).to eq(new_quantity)
       end
     end
+
+    context "for a nil value" do
+      let(:old_colour) { nil }
+      let(:new_colour) { "iridescent" }
+
+      context "by default" do
+        before do
+          Bubble.deidentify :colour, method: :replace, new_value: new_colour
+        end
+
+        it "keeps the nil" do
+          bubble.deidentify!
+
+          expect(bubble.colour).to be_nil
+        end
+      end
+
+      context "when nil should be kept" do
+        before do
+          Bubble.deidentify :colour, method: :replace, new_value: new_colour, keep_nil: true
+        end
+
+        it "keeps the nil" do
+          bubble.deidentify!
+
+          expect(bubble.colour).to be_nil
+        end
+      end
+
+      context "when nil should be replaced" do
+        before do
+          Bubble.deidentify :colour, method: :replace, new_value: new_colour, keep_nil: false
+        end
+
+        it 'replaces the value' do
+          bubble.deidentify!
+
+          expect(bubble.colour).to eq(new_colour)
+        end
+      end
+    end
   end
 
   describe "delete" do


### PR DESCRIPTION
This will maintain the structure of the data more accurately than a blanket replace. I've made this default but optional in case the data being there or not in in fact personal.