### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    deidentify (0.0.6)
+    deidentify (1.0.0)
       rails (>= 5.0.0)
 
 GEM

--- a/deidentify.gemspec
+++ b/deidentify.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'deidentify'
-  s.version     = '0.0.6'
+  s.version     = '1.0.0'
   s.summary     = "Deidentify a rails model"
   s.description = "A gem to allow deidentification of certain fields"
   s.authors     = ["Lucy Dement"]


### PR DESCRIPTION
Both the rename of `BaseHash` and the `keep_nil` option for replace are potentially breaking changes, so bump this a major version.