### PR TITLE
Tech Ex: Handle blanks the same way as nils when deidentifing

### DIFF
--- a/lib/deidentify/base_hash.rb
+++ b/lib/deidentify/base_hash.rb
@@ -3,7 +3,7 @@
 module Deidentify
   class BaseHash
     def self.call(old_value, length: nil)
-      return nil if old_value.nil?
+      return old_value unless old_value.present?
 
       salt = Deidentify.configuration.salt
 

--- a/lib/deidentify/delocalize_ip.rb
+++ b/lib/deidentify/delocalize_ip.rb
@@ -3,7 +3,7 @@
 module Deidentify
   class DelocalizeIp
     def self.call(old_ip, mask_length: nil)
-      return nil if old_ip.nil?
+      return old_ip unless old_ip.present?
 
       addr = IPAddr.new(old_ip)
       addr.mask(mask_length || default_mask(addr)).to_s

--- a/lib/deidentify/hash_email.rb
+++ b/lib/deidentify/hash_email.rb
@@ -6,7 +6,7 @@ module Deidentify
     MAX_DOMAIN_LENGTH = 63
 
     def self.call(old_email, length: 255)
-      return nil if old_email.nil?
+      return old_email unless old_email.present?
 
       half_length = (length - 1) / 2 # the -1 is to account for the @ symbol
 

--- a/lib/deidentify/hash_url.rb
+++ b/lib/deidentify/hash_url.rb
@@ -3,7 +3,7 @@
 module Deidentify
   class HashUrl
     def self.call(old_url, length: 255)
-      return nil if old_url.nil?
+      return old_url unless old_url.present?
 
       uri = URI.parse(old_url)
       uri = URI.parse("http://#{old_url}") if uri.scheme.nil?

--- a/lib/deidentify/replace.rb
+++ b/lib/deidentify/replace.rb
@@ -3,7 +3,7 @@
 module Deidentify
   class Replace
     def self.call(old_value, new_value:, keep_nil: true)
-      return nil if old_value.nil? && keep_nil
+      return old_value if old_value.blank? && keep_nil
 
       new_value
     end

--- a/spec/deidentify/base_hash_spec.rb
+++ b/spec/deidentify/base_hash_spec.rb
@@ -45,6 +45,14 @@ describe Deidentify::BaseHash do
     end
   end
 
+  context 'when the value is blank' do
+    let(:old_value) { '' }
+
+    it 'returns blank' do
+      expect(new_value).to eq old_value
+    end
+  end
+
   describe 'deidentify interface' do
     let(:bubble) { Bubble.create!(colour: old_colour, quantity: old_quantity) }
     let(:old_colour) { 'blue@eiffel65.com' }

--- a/spec/deidentify/delocalize_ip_spec.rb
+++ b/spec/deidentify/delocalize_ip_spec.rb
@@ -18,6 +18,14 @@ describe Deidentify::DelocalizeIp do
     end
   end
 
+  context 'the ip is blank' do
+    let(:old_ip) { '' }
+
+    it 'returns blank string' do
+      expect(new_ip).to eq old_ip
+    end
+  end
+
   context 'when a network mask length is provided' do
     let(:new_ip) { Deidentify::DelocalizeIp.call(old_ip, mask_length: 16) }
 

--- a/spec/deidentify/hash_email_spec.rb
+++ b/spec/deidentify/hash_email_spec.rb
@@ -60,6 +60,14 @@ describe Deidentify::HashEmail do
     end
   end
 
+  context 'the email is blank' do
+    let(:old_email) { '' }
+
+    it 'returns blank' do
+      expect(new_email).to eq old_email
+    end
+  end
+
   describe 'deidentify interface' do
     let(:bubble) { Bubble.create!(colour: old_colour, quantity: old_quantity) }
     let(:old_colour) { 'blue@eiffel65.com' }

--- a/spec/deidentify/hash_url_spec.rb
+++ b/spec/deidentify/hash_url_spec.rb
@@ -81,6 +81,14 @@ describe Deidentify::HashUrl do
     end
   end
 
+  context 'the url is blank' do
+    let(:old_url) { '' }
+
+    it 'returns blank' do
+      expect(new_url).to eq old_url
+    end
+  end
+
   describe 'deidentify interface' do
     let(:bubble) { Bubble.create!(colour: old_colour, quantity: old_quantity) }
     let(:old_colour) { 'blue@eiffel65.com' }

--- a/spec/deidentify/replace_spec.rb
+++ b/spec/deidentify/replace_spec.rb
@@ -35,19 +35,21 @@ describe Deidentify::Replace do
     end
   end
 
-  context 'for a nil value' do
+  context 'for a nil or blank value' do
     let(:old_colour) { nil }
     let(:new_colour) { 'iridescent' }
 
     context 'by default' do
+      let(:old_colour) { '' }
+
       before do
         Bubble.deidentify :colour, method: :replace, new_value: new_colour
       end
 
-      it 'keeps the nil' do
+      it 'keeps the blank' do
         bubble.deidentify!
 
-        expect(bubble.colour).to be_nil
+        expect(bubble.colour).to eq old_colour
       end
     end
 


### PR DESCRIPTION
We discovered that having an empty string in a url column caused the `hash_url` method to throw a zero division error. When I went to fix that I discovered that we're handling blank strings wrong in a lot of places. They should be handled pretty much the same as `nil` this fixes the `hash_url` bug and updates all other deidentification methods to handle blanks and string the same.