### PR TITLE
:platform: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+registries:
+  rubygems-server-github-packages:
+    type: rubygems-server
+    url: https://rubygems.org/
+    token: ${{ secrets.EMPTY_STRING }}
+
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  insecure-external-code-execution: allow
+  schedule:
+    interval: daily
+    time: "06:00"
+    timezone: Pacific/Auckland
+  labels:
+  - dependencies
+  - go
+  allow:
+  - dependency-type: direct
+  - dependency-type: indirect
+  registries:
+  - rubygems-server-github-packages


### PR DESCRIPTION
make dependabot use the `go` label in this repo